### PR TITLE
Fix `brew audit` failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 15 * * *'
+    - cron: '0 0 * * *'
 
 jobs:
   test:
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: brew install --verbose Formula/*.rb
       - run: brew test --verbose Formula/*.rb
-      - run: brew audit --strict Formula/*.rb
+      - run: tools/audit.sh
 
   formula:
     runs-on: ubuntu-18.04

--- a/tools/audit.sh
+++ b/tools/audit.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euxo pipefail
+IFS=$'\n\t'
+
+# Audit formulas.
+#
+# USAGE:
+#    ./tools/audit.sh
+
+tap_name=openrr/test
+brew tap-new --no-git "${tap_name}"
+cp Formula/*.rb "$(brew --repo "${tap_name}")"/Formula
+
+if [[ -n "${CI:-}" ]]; then
+    for formula in Formula/*.rb; do
+        formula="$(basename "${formula%.*}")"
+        brew uninstall "${tap_name}/${formula}"
+    done
+fi
+
+for formula in Formula/*.rb; do
+    formula="$(basename "${formula%.*}")"
+    brew audit --strict "${tap_name}/${formula}"
+done
+
+brew untap "${tap_name}"

--- a/tools/formula.sh
+++ b/tools/formula.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
 
 # Update formulas.
 #
-# Usage:
+# USAGE:
 #    ./tools/formula.sh
-
-set -euo pipefail
-IFS=$'\n\t'
 
 OWNER="openrr"
 PACKAGES=(


### PR DESCRIPTION
https://github.com/openrr/homebrew-tap/runs/4472394571?check_suite_focus=true
```text
Error: undefined method `path' for nil:NilClass
Did you mean?  paths
Do not report this issue until you've run `brew update` and tried again.
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula_auditor.rb:124:in `audit_synced_versions_formulae'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula_auditor.rb:823:in `block in audit'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula_auditor.rb:818:in `each'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula_auditor.rb:818:in `audit'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/audit.rb:185:in `block in audit'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/audit.rb:169:in `map'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/audit.rb:169:in `audit'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:110:in `<main>'
```

refs: https://github.com/Homebrew/brew/issues/12506#issuecomment-986657698