### PR TITLE
Disable audit on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       - run: brew install --verbose Formula/*.rb
       - run: brew test --verbose Formula/*.rb
       - run: tools/audit.sh
+        if: startsWith(matrix.os, 'macos') # disable on Linux due to an upstream bug
 
   formula:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
```
homebrew/core:
  * audit_exceptions/versioned_formula_dependent_conflicts_allowlist.json references
    formulae or casks that are not found in the homebrew/core tap.
    Invalid formulae or casks: python
```