### PR TITLE
Use x86_86 binary on aarch64 macOS

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -1,3 +1,4 @@
+aarch
 euxo
 linuxbrew
 openrr

--- a/Formula/urdf-viz.rb
+++ b/Formula/urdf-viz.rb
@@ -7,7 +7,11 @@ class UrdfViz < Formula
   license "Apache-2.0"
 
   on_macos do
-    if Hardware::CPU.intel?
+    if Hardware::CPU.arm?
+      # TODO: distribute aarch64 binary
+      url "https://github.com/openrr/urdf-viz/releases/download/v0.45.0/urdf-viz-x86_64-apple-darwin.tar.gz"
+      sha256 "dbb0b460ec1f576a2c4921d9af7eb451a95a63c2f2b75fcf8569bc09ce51b3e5"
+    else
       url "https://github.com/openrr/urdf-viz/releases/download/v0.45.0/urdf-viz-x86_64-apple-darwin.tar.gz"
       sha256 "dbb0b460ec1f576a2c4921d9af7eb451a95a63c2f2b75fcf8569bc09ce51b3e5"
     end

--- a/tools/formula.sh
+++ b/tools/formula.sh
@@ -41,7 +41,11 @@ class ${class} < Formula
   license "Apache-2.0"
 
   on_macos do
-    if Hardware::CPU.intel?
+    if Hardware::CPU.arm?
+      # TODO: distribute aarch64 binary
+      url "${mac_url}"
+      sha256 "${mac_sha%  *}"
+    else
       url "${mac_url}"
       sha256 "${mac_sha%  *}"
     end

--- a/tools/spell-check.sh
+++ b/tools/spell-check.sh
@@ -45,7 +45,7 @@ if [[ -n "$(git ls-files '*Cargo.toml')" ]]; then
     dependencies=$(sed <<<"${dependencies}" 's/[0-9_-]/\n/g' | LC_ALL=C sort -f -u)
 fi
 config_old=$(<.cspell.json)
-config_new=$(grep <<<"${config_old}" -v ' *//' | jq 'del(.dictionaries[])' | jq 'del(.dictionaryDefinitions[])')
+config_new=$(grep <<<"${config_old}" -v '^ *//' | jq 'del(.dictionaries[])' | jq 'del(.dictionaryDefinitions[])')
 trap -- 'echo "${config_old}" >.cspell.json; echo >&2 "$0: trapped SIGINT"; exit 1' SIGINT
 echo "${config_new}" >.cspell.json
 if [[ -n "${has_rust}" ]]; then


### PR DESCRIPTION
x86_86 binary also works on aarch64 macOS. Ideally, we should distribute aarch64 binary, but I remember that when I tried it before, it failed to cross-compile (but maybe it was solved by https://github.com/openrr/urdf-viz/pull/240).

Closes https://github.com/openrr/urdf-viz/issues/233