### PR TITLE
ci: Use ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
           - macos-latest
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -39,7 +39,7 @@ jobs:
       # - run: tools/audit.sh # disable due to an upstream bug
 
   formula:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: write


### PR DESCRIPTION
ubuntu-20.04 has been removed.
https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/